### PR TITLE
PESD-135: Add AI tools to tech radar

### DIFF
--- a/data.json
+++ b/data.json
@@ -684,5 +684,47 @@
     "quadrant": "platforms",
     "isNew": "TRUE",
     "description": "MS-SQL compatibility layer for AWS Aurora PostgreSQL"
+  },
+  {
+    "name": "ChatGPT",
+    "ring": "adopt",
+    "quadrant": "tools",
+    "isNew": "TRUE",
+    "description": "AI-powered general assistant by OpenAI for writing, brainstorming, and analysis. <a href=\"https://paymentology.atlassian.net/wiki/spaces/AI/pages/9617866859/ChatGPT\" target=\"_blank\">Internal docs</a>"
+  },
+  {
+    "name": "PayAI",
+    "ring": "adopt",
+    "quadrant": "tools",
+    "isNew": "TRUE",
+    "description": "AI-powered search assistant in Slack for internal knowledge. <a href=\"https://paymentology.atlassian.net/wiki/spaces/AI/pages/8853782530/PayAI\" target=\"_blank\">Internal docs</a>"
+  },
+  {
+    "name": "Microsoft Copilot Chat",
+    "ring": "adopt",
+    "quadrant": "tools",
+    "isNew": "TRUE",
+    "description": "AI assistant integrated with Microsoft 365 (Teams, Outlook, web). <a href=\"https://paymentology.atlassian.net/wiki/spaces/AI/pages/8807481498/Copilot+Chat\" target=\"_blank\">Internal docs</a>"
+  },
+  {
+    "name": "AWS Bedrock",
+    "ring": "adopt",
+    "quadrant": "tools",
+    "isNew": "TRUE",
+    "description": "AI model access platform in AWS for production workloads. <a href=\"https://paymentology.atlassian.net/wiki/spaces/AI/pages/9617834023/AWS+Bedrock\" target=\"_blank\">Internal docs</a>"
+  },
+  {
+    "name": "Cursor",
+    "ring": "trial",
+    "quadrant": "tools",
+    "isNew": "TRUE",
+    "description": "AI-native IDE under evaluation as complement to GitHub Copilot. <a href=\"https://paymentology.atlassian.net/wiki/spaces/AI/pages/9650503820/Cursor\" target=\"_blank\">Internal docs</a>"
+  },
+  {
+    "name": "Windsurf",
+    "ring": "hold",
+    "quadrant": "tools",
+    "isNew": "TRUE",
+    "description": "AI-powered IDE, not formally approved for general use. Security review pending. <a href=\"https://paymentology.atlassian.net/wiki/spaces/AI/pages/9650503843/Windsurf\" target=\"_blank\">Internal docs</a>"
   }
 ]


### PR DESCRIPTION
## Summary

Add 6 new AI tool entries to the tech radar, sourced from the [AI tools in Paymentology](https://paymentology.atlassian.net/wiki/spaces/AI/pages/8807612563/AI+tools+in+Paymentology) Confluence page.

## New entries (all in `tools` quadrant)

| Tool | Ring | Description |
|------|------|-------------|
| ChatGPT | adopt | AI-powered general assistant by OpenAI |
| PayAI | adopt | AI-powered search assistant in Slack |
| Microsoft Copilot Chat | adopt | AI assistant integrated with Microsoft 365 |
| AWS Bedrock | adopt | AI model access platform in AWS |
| Cursor | trial | AI-native IDE under evaluation |
| Windsurf | hold | AI-powered IDE, not formally approved |

Each entry includes a link to its corresponding Confluence documentation page.

## Jira

[PESD-135](https://paymentology.atlassian.net/browse/PESD-135)

[PESD-135]: https://paymentology.atlassian.net/browse/PESD-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ