### PR TITLE
feat: Adding AWS MWAA under trial for Data Platform orchestration

### DIFF
--- a/data.json
+++ b/data.json
@@ -782,5 +782,12 @@
     "quadrant": "platforms",
     "isNew": "TRUE",
     "description": "Managed schema registry in AWS for validating and controlling the evolution of streaming data schemas. Supports Avro, JSON Schema, and Protobuf formats. Integrates with MSK, Kafka, and Glue Catalog."
+  },
+  {
+    "name": "AWS MWAA",
+    "ring": "trial",
+    "quadrant": "platforms",
+    "isNew": "TRUE",
+    "description": "Amazon Managed Workflows for Apache Airflow. Managed orchestration service for data pipelines using Apache Airflow."
   }
 ]


### PR DESCRIPTION
- Adding AWS MWAA as a trial platform to test for Data Platform data pipeline orchestration. Architecture document: https://paymentology.atlassian.net/wiki/spaces/pa/pages/9515827525/SDD+Paymentology+Strategic+Data+Platform#9.10-Logical-View